### PR TITLE
Delete legacy webhooks after installing Github app

### DIFF
--- a/lib/codeship_migrate_to_github_app/cli.rb
+++ b/lib/codeship_migrate_to_github_app/cli.rb
@@ -12,7 +12,7 @@ module CodeshipMigrateToGithubApp
 
     CODESHIP_AUTH_URL = "https://api.codeship.com/v2/auth"
     GITHUB_ORGS_URL = "https://api.github.com/user/orgs"
-    CODESHIP_MIGRATION_INFO_URL = "https://api.codeship.com/v2/internal/github_app_migrations"
+    CODESHIP_MIGRATION_INFO_URL = "https://api.codeship.com/v2/internal/github_app_migration"
     GITHUB_INSTALL_URL = "https://api.github.com/user/installations/{installation_id}/repositories/{repository_id}"
     GITHUB_LIST_HOOKS_URL = "https://api.github.com/repos/{owner}/{repo}/hooks"
     GITHUB_DELETE_HOOK_URL = "https://api.github.com/repos/{owner}/{repo}/hooks/{hook_id}"
@@ -67,16 +67,18 @@ module CodeshipMigrateToGithubApp
           raise Thor::Error.new "Error retrieving migration info from CodeShip: #{response.code}: #{response.to_s}"
         end
 
-        @codeship_migration_info = response.parse
+        @codeship_migration_info = response.parse&.fetch("installations")&.fetch("installations")
       end
 
       def migrate
         @codeship_migration_info.each do |installation|
           installation["repositories"].each do |repo|
+            puts "DEBUG about to install to #{github_install_url(installation["installation_id"], repo["repository_id"])}"
             response = HTTP.headers(accept: GITHUB_INSTALLATIONS_PREVIEW_HEADER)
                            .auth("token #{@github_token}")
                            .put(github_install_url(installation["installation_id"], repo["repository_id"]))
             unless response.code == 204
+              puts "DEBUG an error installing app for #{repo["repository_name"]}, error code #{response.code}"
               @errors << repo["repository_name"]
             end
             remove_legacy_service(repo["repository_name"])
@@ -101,8 +103,11 @@ module CodeshipMigrateToGithubApp
         response = HTTP.headers(accept: GITHUB_JSON_HEADER)
                        .auth("token #{@github_token}")
                        .get(github_list_hooks_url(owner, repo))
-        hook = response.parse.find do |hook|
-          hook["name"] == 'codeship'
+        puts "DEBUG looking for legacy hooks for #{owner} #{repo}, got #{response.code}"
+        if response.code == 200
+          hook = response.parse.find do |hook|
+            hook["name"] == 'codeship'
+          end
         end
         hook&.fetch("id")
       end
@@ -111,6 +116,7 @@ module CodeshipMigrateToGithubApp
         response = HTTP.headers(accept: GITHUB_JSON_HEADER)
                        .auth("token #{@github_token}")
                        .delete(github_delete_hook_url(owner, repo, hook_id))
+        puts "DEBUG deleting hook, got a #{response.code}"
       end
 
       def parse_repo_name(repo_name)

--- a/spec/codeship_migrate_to_github_app_spec.rb
+++ b/spec/codeship_migrate_to_github_app_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe CodeshipMigrateToGithubApp::CLI do
     {
         codeship_auth: "https://api.codeship.com/v2/auth",
         github_orgs: "https://api.github.com/user/orgs",
-        codeship_migration: "https://api.codeship.com/v2/internal/github_app_migrations",
+        codeship_migration: "https://api.codeship.com/v2/internal/github_app_migration",
         github_install: Addressable::Template.new("https://api.github.com/user/installations/{installation_id}/repositories/{repository_id}"),
         github_hooks: Addressable::Template.new("https://api.github.com/repos/{owner}/{repo}/hooks")
    }
@@ -36,7 +36,7 @@ RSpec.describe CodeshipMigrateToGithubApp::CLI do
     before(:each) do
       stub_request(:post, urls[:codeship_auth]).to_return(status: 200, headers: JSON_TYPE, body: '{"access_token": "abc123", "organizations":[{"uuid":"86ca6be0-413d-0134-079f-1e81b891aacf","name":"joshco"},{"uuid":"c00d11a0-383b-0136-dfac-0aa9c93fd8f3","name":"partial-match-76"}]}')
       stub_request(:get, urls[:github_orgs]).to_return(status: 200, headers: JSON_TYPE, body: '[{"login": "joshco", "id": 123, "url": "https://api.github.com/orgs/joshco"}]')
-      stub_request(:get, urls[:codeship_migration]).to_return(status: 200, headers: JSON_TYPE, body: '[{"installation_id":"123","repositories":[{"repository_id":"7777","repository_name":"foo/bar"},{"repository_id":"8888","repository_name":"foo/foo"}]},{"installation_id":"456","repositories":[{"repository_id":"9999","repository_name":"bar/bar"}]}]')
+      stub_request(:get, urls[:codeship_migration]).to_return(status: 200, headers: JSON_TYPE, body: '{"installations":{"installations":[{"installation_id":"123","repositories":[{"repository_id":"7777","repository_name":"foo/bar"},{"repository_id":"8888","repository_name":"foo/foo"}]},{"installation_id":"456","repositories":[{"repository_id":"9999","repository_name":"bar/bar"}]}]}}')
       stub_request(:put, urls[:github_install]).to_return(status: 204, headers: JSON_TYPE, body: '')
       stub_request(:get, urls[:github_hooks]).to_return(status: 200, headers: JSON_TYPE, body: '[]')
     end
@@ -122,7 +122,7 @@ RSpec.describe CodeshipMigrateToGithubApp::CLI do
 
     context "no repos to migrate" do
       before(:each) do
-        stub_request(:get, urls[:codeship_migration]).to_return(status: 200, headers: JSON_TYPE, body: '[]')
+        stub_request(:get, urls[:codeship_migration]).to_return(status: 200, headers: JSON_TYPE, body: '{"installations":{"installations":[]}}')
       end
 
       it { expect{command}.to_not raise_error }


### PR DESCRIPTION
After installing a GitHub app for a repo, look for a legacy CodeShip web hook and delete it if found