### PR TITLE
[SHIP-2671] Migrate - Update App URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Give your token a descriptive name, click 'Generate token', and you'll be taken 
 
 For each GitHub organization containing repositories to migrate, you'll need to install the CodeShip GitHub App and add it to at least one repository.
 
-- Install the CodeShip GitHub App for your organization by visiting  <https://github.com/apps/codeship/installations/new>
+- Install the CodeShip GitHub App for your organization by visiting  <https://github.com/apps/cloudbees/installations/new>
 - Select your organization
 - Under "Repository Access" select "Only select repositories", and choose at least one repository
 - Click save. You'll be redirected back to CodeShip and can safely close the browser window


### PR DESCRIPTION
For the codeship_migrate_to_github_app repo, changes the GitHub app URL from https://github.com/apps/codeship

to:

https://github.com/apps/cloudbees